### PR TITLE
refactor(wiki): replace gitea wiki urls with wiki.btcmap.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ https://www.openstreetmap.org
 
 Absolutely, you are very welcome to do that. This is a good place to start:
 
-[Tagging Instructions](https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants)
+[Tagging Instructions](https://wiki.btcmap.org/Tagging-Merchants)
 
 ### BTC Map shows a place which doesn't exist, how can I delete it?
 

--- a/app/src/main/kotlin/org/btcmap/place/PlaceFragment.kt
+++ b/app/src/main/kotlin/org/btcmap/place/PlaceFragment.kt
@@ -204,7 +204,7 @@ class PlaceFragment : Fragment() {
         }
 
         val outdatedUri =
-            "https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Verifying-Existing-Merchants".toUri()
+            "https://wiki.btcmap.org/Verifying-Existing-Merchants".toUri()
 
         if (place.verifiedAt != null) {
             val date = DateUtils.getRelativeDateTimeString(


### PR DESCRIPTION
Replaces all BTC Map wiki base URLs from `https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/` to `https://wiki.btcmap.org/` across the codebase.

**Files changed:**
- `README.md`
- `app/src/main/kotlin/org/btcmap/place/PlaceFragment.kt`

🤖 Generated with [opencode](https://opencode.ai)